### PR TITLE
Adding fix so stream fields can be pickled and unpickled correctly

### DIFF
--- a/wagtail/admin/rich_text/converters/html_ruleset.py
+++ b/wagtail/admin/rich_text/converters/html_ruleset.py
@@ -97,3 +97,11 @@ class HTMLRuleset():
         for precedence, attr_check, result in rules_to_test:
             if attr_check(attrs):
                 return result
+
+    def __getstate__(self):
+        '''
+        When pickling this object (for caching) we ignore these rules, hence
+        returning an empty dictionary in place of real state. Without this,
+        we get pickle errors when trying to cache ContentPiece objects.
+        '''
+        return {}

--- a/wagtail/core/blocks/base.py
+++ b/wagtail/core/blocks/base.py
@@ -414,44 +414,6 @@ class Block(metaclass=BaseBlock):
         return (self.name == other.name) and (self.deconstruct() == other.deconstruct())
 
 
-    def __getstate__(self):
-        """Hook to allow choosing the attributes to pickle."""
-        state = self.__dict__.copy()
-
-        if "meta" in state and hasattr(state["meta"], "__dict__"):
-            state["meta"] = state["meta"].__dict__
-
-        if "dependencies" in state:
-            state["dependencies"] = list(state["dependencies"])
-
-        if (
-            "field" in state
-            and hasattr(state["field"], "choices")
-            and isinstance(state["field"].choices, CallableChoiceIterator)
-        ):
-            state["field"].choices = list(state["field"].choices)
-
-        return state
-
-    def __setstate__(self, state):
-        from collections import OrderedDict
-        self.meta = self._meta_class()
-
-        if 'meta' in state:
-            self.meta.__dict__.update(state.pop('meta'))
-
-        if "dependencies" in state:
-            deps = OrderedDict([])
-            for idx, x in enumerate(state["dependencies"]):
-                deps[idx] = x
-            state["dependencies"] = deps.values()
-
-        if "field" in state and hasattr(state["field"], "choices"):
-            state["field"].choices = CallableChoiceIterator(state["field"].choices)
-
-        self.__dict__.update(state)
-
-
 class BoundBlock:
     def __init__(self, block, value, prefix=None, errors=None):
         self.block = block

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -477,3 +477,7 @@ class StreamValue(Sequence):
 
     def __str__(self):
         return self.__html__()
+
+    def __getnewargs_ex__(self):
+        return ((self.stream_block, self.stream_data), {"is_lazy": self.is_lazy, "raw_text": self.raw_text})
+

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -9,6 +9,7 @@ from django.template.loader import render_to_string
 from django.utils.html import format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
+from django.db.models.fields import _load_field
 
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.core.utils import escape_script
@@ -478,6 +479,22 @@ class StreamValue(Sequence):
     def __str__(self):
         return self.__html__()
 
-    def __getnewargs_ex__(self):
-        return ((self.stream_block, self.stream_data), {"is_lazy": self.is_lazy, "raw_text": self.raw_text})
+    def _stream_value_loader(app_label, model_name, field_name, field_value):
+        """Returns StreamValue from pickled data"""
+        stream_field = _load_field(app_label, model_name, field_name)
+        stream_value = stream_field.stream_block.to_python(field_value)
+        stream_value._field = stream_field
+        return stream_value
+
+    def __reduce__(self) -> tuple:
+        """Reducer to make this class pickleable."""
+        return (
+            StreamValue._stream_value_loader,
+            (
+                self._field.model._meta.app_label,
+                self._field.model._meta.object_name,
+                self._field.name,
+                self.get_prep_value(),
+            ),
+        )
 


### PR DESCRIPTION
# Notes
This change implements the picking fix proposed by PySilver [1]. Whilst the previous version of the PR used the higher level APIs (__getstate__, __setstate__ and __getnewargs_ex__), it was actually a lot slower than proposed fix. Some testing indicates it was **5x** slower for unpickling.

**I have also updated the HTMLRuleset class with some custom pickling logic to prevent further pickling errors.**

**Note:** The current plan is to reference this branch in this forked version of Wagtail [4] as part of the Chivas set up. And to later submit a PR to Wagtail.

# Testing
So far this has been manually tested in shell_plus (see below):

```
% from django.core.cache import cache
% ch = ContentPieceChapter.objects.filter(title='Test')[0]
% ch.blocks
[<wagtail.core.blocks.stream_block.StreamValue.StreamChild object at 0x12b3c52b0>, <wagtail.core.blocks.stream_block.StreamValue.StreamChild object at 0x12b3c5dd8>]

% cache.set('ch', ch)
% c = cache.get('ch')
% c.blocks
[<wagtail.core.blocks.stream_block.StreamValue.StreamChild object at 0x12b3dc668>, <wagtail.core.blocks.stream_block.StreamValue.StreamChild object at 0x12b3dc5f8>]
```

[1] PySilver pickle fix proposal: https://github.com/wagtail/wagtail/pull/5998#issuecomment-649871987
